### PR TITLE
Added needed dependency: rsync

### DIFF
--- a/karellen-sysbox.spec
+++ b/karellen-sysbox.spec
@@ -30,6 +30,7 @@ Requires: (docker or docker-ce)
 Requires: systemd
 Requires: fuse
 Requires: libseccomp
+Requires: rsync
 
 Provides: sysbox
 


### PR DESCRIPTION
When installing and starting sysbox, if rsync isn't installed sysbox-mgr crashes